### PR TITLE
Fix specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
+.ruby-version
 Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ Style/BlockDelimiters:
 Style/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
+
+Style/DateTime:
+  Exclude:
+    - 'lib/snowplow_ruby_duid/cookie.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,7 @@ Metrics/LineLength:
 Style/BlockDelimiters:
   Exclude:
     - 'spec/lib/snowplow_ruby_duid/cookie_spec.rb'
+
+Style/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in snowplow_ruby_duid.gemspec

--- a/lib/snowplow_ruby_duid.rb
+++ b/lib/snowplow_ruby_duid.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'digest/sha1'
 require 'snowplow_ruby_duid/cookie'
 require 'snowplow_ruby_duid/domain_userid'
 require 'snowplow_ruby_duid/helper'
 
 module SnowplowRubyDuid
-  KEY_PREFIX = '_sp_id'.freeze
+  KEY_PREFIX = '_sp_id'
 end
 
 ActionController::Base.send :include, SnowplowRubyDuid::Helper if defined?(ActionController)

--- a/lib/snowplow_ruby_duid.rb
+++ b/lib/snowplow_ruby_duid.rb
@@ -6,7 +6,7 @@ require 'snowplow_ruby_duid/domain_userid'
 require 'snowplow_ruby_duid/helper'
 
 module SnowplowRubyDuid
-  KEY_PREFIX = '_sp_id'
+  KEY_PREFIX = '_sp_id'.freeze
 end
 
 ActionController::Base.send :include, SnowplowRubyDuid::Helper if defined?(ActionController)

--- a/lib/snowplow_ruby_duid/cookie.rb
+++ b/lib/snowplow_ruby_duid/cookie.rb
@@ -5,7 +5,7 @@ module SnowplowRubyDuid
   # Leverages the method used by ActionDispatch::Cookies::CookieJar to determine the top-level domain
   class Cookie
     # See: https://github.com/snowplow/snowplow-javascript-tracker/blob/d3d10067127eb5c95d0054c8ae60f3bdccba619d/src/js/tracker.js#L142
-    COOKIE_PATH            = '/'
+    COOKIE_PATH            = '/'.freeze
     # See: https://github.com/snowplow/snowplow-javascript-tracker/blob/d3d10067127eb5c95d0054c8ae60f3bdccba619d/src/js/tracker.js#L156
     COOKIE_DURATION_MONTHS = 24
     # See: https://github.com/rails/rails/blob/b1124a2ac88778c0feb0157ac09367cbd204bf01/actionpack/lib/action_dispatch/middleware/cookies.rb#L214

--- a/lib/snowplow_ruby_duid/cookie.rb
+++ b/lib/snowplow_ruby_duid/cookie.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 module SnowplowRubyDuid
   # Responsible for generating a cookie that emulates the Snowplow cookie as closely as possible
   # Leverages the method used by ActionDispatch::Cookies::CookieJar to determine the top-level domain
   class Cookie
     # See: https://github.com/snowplow/snowplow-javascript-tracker/blob/d3d10067127eb5c95d0054c8ae60f3bdccba619d/src/js/tracker.js#L142
-    COOKIE_PATH            = '/'.freeze
+    COOKIE_PATH            = '/'
     # See: https://github.com/snowplow/snowplow-javascript-tracker/blob/d3d10067127eb5c95d0054c8ae60f3bdccba619d/src/js/tracker.js#L156
     COOKIE_DURATION_MONTHS = 24
     # See: https://github.com/rails/rails/blob/b1124a2ac88778c0feb0157ac09367cbd204bf01/actionpack/lib/action_dispatch/middleware/cookies.rb#L214
-    DOMAIN_REGEXP          = /[^.]*\.([^.]*|..\...|...\...)$/
+    DOMAIN_REGEXP          = /[^.]*\.([^.]*|..\...|...\...)$/.freeze
 
     def initialize(host, domain_userid, request_created_at)
       @host               = host
@@ -25,10 +27,10 @@ module SnowplowRubyDuid
     def value
       cookie_domain = ".#{top_level_domain}" unless top_level_domain.nil?
       {
-        value:   cookie_value,
+        value: cookie_value,
         expires: cookie_expiration,
-        domain:  cookie_domain,
-        path:    COOKIE_PATH
+        domain: cookie_domain,
+        path: COOKIE_PATH
       }
     end
 

--- a/lib/snowplow_ruby_duid/domain_userid.rb
+++ b/lib/snowplow_ruby_duid/domain_userid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module SnowplowRubyDuid

--- a/lib/snowplow_ruby_duid/domain_userid.rb
+++ b/lib/snowplow_ruby_duid/domain_userid.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module SnowplowRubyDuid
   # Generates a pseudo-unique ID to fingerprint the user
   # Deviates from this Snowplow Javascript: https://github.com/snowplow/snowplow-javascript-tracker/blob/d3d10067127eb5c95d0054c8ae60f3bdccba619d/src/js/tracker.js#L468-L472

--- a/lib/snowplow_ruby_duid/helper.rb
+++ b/lib/snowplow_ruby_duid/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SnowplowRubyDuid
   # Exposes a snowplow_domain_userid method in the context
   # that will find or create a domain_userid, which will be

--- a/lib/snowplow_ruby_duid/helper.rb
+++ b/lib/snowplow_ruby_duid/helper.rb
@@ -9,10 +9,11 @@ module SnowplowRubyDuid
       @snowplow_domain_userid ||= find_or_create_snowplow_domain_userid
     end
 
+    private
+
     def find_or_create_snowplow_domain_userid
       find_snowplow_domain_userid || create_snowplow_domain_userid
     end
-    private :find_or_create_snowplow_domain_userid
 
     def create_snowplow_domain_userid
       request_created_at = Time.now
@@ -22,7 +23,6 @@ module SnowplowRubyDuid
       response.set_cookie snowplow_cookie.key, snowplow_cookie.value
       domain_userid
     end
-    private :create_snowplow_domain_userid
 
     # See: https://github.com/snowplow/snowplow/wiki/Ruby-Tracker#310-setting-the-domain-user-id-with-set_domain_user_id
     def find_snowplow_domain_userid
@@ -30,11 +30,9 @@ module SnowplowRubyDuid
       # The cookie value is in this format: domainUserId.createTs.visitCount.nowTs.lastVisitTs
       snowplow_cookie.last.split('.').first unless snowplow_cookie.nil?
     end
-    private :find_snowplow_domain_userid
 
     def find_snowplow_cookie
       request.cookies.find { |(key, _value)| key =~ /^#{KEY_PREFIX}/ } # result will be an array containing: [key, value]
     end
-    private :find_snowplow_cookie
   end
 end

--- a/lib/snowplow_ruby_duid/version.rb
+++ b/lib/snowplow_ruby_duid/version.rb
@@ -1,3 +1,3 @@
 module SnowplowRubyDuid
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/lib/snowplow_ruby_duid/version.rb
+++ b/lib/snowplow_ruby_duid/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SnowplowRubyDuid
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.2'
 end

--- a/lib/snowplow_ruby_duid/version.rb
+++ b/lib/snowplow_ruby_duid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SnowplowRubyDuid
-  VERSION = '1.0.2'
+  VERSION = '1.0.2'.freeze
 end

--- a/snowplow_ruby_duid.gemspec
+++ b/snowplow_ruby_duid.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'snowplow_ruby_duid/version'
 

--- a/spec/lib/snowplow_ruby_duid/cookie_spec.rb
+++ b/spec/lib/snowplow_ruby_duid/cookie_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SnowplowRubyDuid
   describe Cookie do
     before do
@@ -17,10 +19,10 @@ module SnowplowRubyDuid
     describe '#value' do
       it 'generates a cookie' do
         expect(subject.value).to eq(
-          domain:  '.simplybusiness.co.uk',
+          domain: '.simplybusiness.co.uk',
           expires: (DateTime.parse '2017-01-22 15:26:31 +0000').to_time,
-          path:    '/',
-          value:   'domain_user_id.1421940391.0.1421940391.'
+          path: '/',
+          value: 'domain_user_id.1421940391.0.1421940391.'
         )
       end
     end

--- a/spec/lib/snowplow_ruby_duid/cookie_spec.rb
+++ b/spec/lib/snowplow_ruby_duid/cookie_spec.rb
@@ -5,7 +5,7 @@ module SnowplowRubyDuid
     before do
       @host               = 'www.simplybusiness.co.uk'
       @domain_userid      = 'domain_user_id'
-      @request_created_at = (DateTime.parse '2015-01-22 15:26:31 +0000').to_time
+      @request_created_at = (Time.parse '2015-01-22 15:26:31 +0000').to_time
     end
 
     subject { described_class.new @host, @domain_userid, @request_created_at }
@@ -20,7 +20,7 @@ module SnowplowRubyDuid
       it 'generates a cookie' do
         expect(subject.value).to eq(
           domain: '.simplybusiness.co.uk',
-          expires: (DateTime.parse '2017-01-22 15:26:31 +0000').to_time,
+          expires: (Time.parse '2017-01-22 15:26:31 +0000').to_time,
           path: '/',
           value: 'domain_user_id.1421940391.0.1421940391.'
         )
@@ -37,7 +37,7 @@ module SnowplowRubyDuid
       end
 
       step 'the time is :time' do |time|
-        @request_created_at = (DateTime.parse time).to_time
+        @request_created_at = (Time.parse time).to_time
       end
 
       step 'I create a Snowplow cookie' do; end

--- a/spec/lib/snowplow_ruby_duid/domain_userid_spec.rb
+++ b/spec/lib/snowplow_ruby_duid/domain_userid_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SnowplowRubyDuid
   describe DomainUserid do
     subject { described_class.new.to_s }

--- a/spec/lib/snowplow_ruby_duid/helper_spec.rb
+++ b/spec/lib/snowplow_ruby_duid/helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack'
 require 'rack/test'
 require 'timecop'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 require 'snowplow_ruby_duid'
 


### PR DESCRIPTION
This PR fixes the Semaphore build. It was failing due to missing require for `securerandom`

(plus it ignores .ruby-version)

(plus it corrects rubocop offenses)

@simplybusiness/developers @simplybusiness/dna-devs 